### PR TITLE
Added Starter Code for Signed Home Page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,12 +1,34 @@
 import React from "react";
+import { 
+  ApolloClient, 
+  ApolloProvider, 
+  InMemoryCache,
+  createHttpLink, 
+} from "@apollo/client";
+import { setContext } from '@apollo/client/link/context';
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
-import { ApolloClient, ApolloProvider, InMemoryCache } from "@apollo/client";
-// import SearchBooks from "./pages/SearchBooks";
-// import SavedBooks from "./pages/SavedBooks";
+
+import UserHome from './pages/UserHome';
 import Navbar from "./components/Navbar";
 
+const httpLink = createHttpLink({
+  uri: '/graphql',
+});
+
+const authLink = setContext((_, { headers }) => {
+  // get the authentication token from local storage if it exists
+  const token = localStorage.getItem('id_token');
+
+  return { 
+    headers: {
+      ...headers,
+      authorization: token ? `Bearer ${token}` : '',
+    },
+  };
+});
+console.log('****');
 const client = new ApolloClient({
-  uri: "/graphql",
+  link: authLink.concat(httpLink),
   cache: new InMemoryCache(),
 });
 
@@ -18,7 +40,10 @@ function App() {
           <Navbar />
           <Routes>
             {/* <Route path="/" element={<SearchBooks />} /> */}
-            {/* <Route path="/saved" element={<SavedBooks />} /> */}
+            <Route 
+              path="/userhome" 
+              element={<UserHome />} 
+            />
             <Route
               path="*"
               element={<h1 className="display-2">Wrong page!</h1>}

--- a/client/src/pages/UserHome.js
+++ b/client/src/pages/UserHome.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useQuery } from '@apollo/client';
+
+import { GET_ME } from '../utils/queries';
+
+const UserHome = () => {
+
+    const { loading, error, data } = useQuery(GET_ME);
+    const userData = data?.me;
+
+    if (error) return `Error! ${error.message}`;
+    if (loading) return 'Loading...';
+
+    return (
+        <div>
+            <h2>Hello {userData.username}</h2>
+            <p>_id: {userData._id}</p>
+            <p>email: {userData.email}</p>
+        </div>
+    );
+};
+
+export default UserHome;

--- a/client/src/utils/auth.js
+++ b/client/src/utils/auth.js
@@ -35,7 +35,7 @@ class AuthService {
   login(idToken) {
     // Saves user token to localStorage
     localStorage.setItem('id_token', idToken);
-    window.location.assign('/');
+    window.location.assign('/userhome');
   }
 
   logout() {

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -1,0 +1,19 @@
+import { gql } from '@apollo/client';
+
+export const GET_ME = gql`
+    query Me {
+        me {
+            _id
+            email
+            username
+            loggedDays {
+                createdAt
+                entries {
+                  _id
+                  calories
+                  item
+                }
+            }
+        }
+    }
+`;

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -6,9 +6,9 @@ const resolvers = {
   Query: {
     me: async (parent, args, context) => {
         if (context.user) {
-            return User.findOne({ _id: context.user._id }).populate('loggedDays');
+            return User.findOne({ _id: context.user._id });
         }
-        throw new AuthenticationError('You need to be logged in!');
+        throw new AuthenticationError('(query.me): You need to be logged in!');
     },
     users: async () => {
       return User.find();

--- a/server/utils/auth.js
+++ b/server/utils/auth.js
@@ -7,16 +7,16 @@ module.exports = {
   authMiddleware: function ({ req }) {
     // allows token to be sent via  req.query or headers
     let token = req.headers.authorization;
-
+    
     // ["Bearer", "<tokenvalue>"]
     if (req.headers.authorization) {
       token = token.split(' ').pop().trim();
     }
-
+    
     if (!token) {
       return req;
     }
-
+    
     // if token can be verified, add the decoded user's data to the request so it can be accessed in the resolver
     try {
       const { data } = jwt.verify(token, secret, { maxAge: expiration });


### PR DESCRIPTION
**App.js**
- Added middleware for setContext. Let's us validate user token without explicitly checking.

**auth.js**
- On login, redirect user to '/userhome'

**client/../utils/queries.js**
- Added GET_ME query that returns the logged in user's data

**UserHome.js**
- Runs GET_ME on page load, making user's data accessible on front end
- Need to add Component for showing current day, and existing entries